### PR TITLE
feat: Add SpringDoc (Swagger Docs) for api project

### DIFF
--- a/apps/api/build.gradle.kts
+++ b/apps/api/build.gradle.kts
@@ -10,6 +10,8 @@ dependencies {
 	implementation(local.spring.boot.starter)
 	implementation(local.spring.boot.starter.web)
 
+	implementation(local.springdoc.openapi.starter.webmvc)
+
 	testImplementation(local.spring.boot.starter.test)
 	testImplementation(local.kotlin.test.junit5)
 	testRuntimeOnly(local.junit.platform.launcher)

--- a/apps/api/src/main/kotlin/com/github/sample/controller/CustomerController.kt
+++ b/apps/api/src/main/kotlin/com/github/sample/controller/CustomerController.kt
@@ -1,6 +1,7 @@
 package com.github.sample.controller
 
 import com.github.sample.Customer
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
@@ -16,6 +17,10 @@ class CustomerController {
      * @return [Customer]
      */
     @GetMapping("/customer")
+    @Operation(
+        summary = "Retrieve a sample customer",
+        description = "Retrieve a sample customer"
+    )
     fun getCustomer(): ResponseEntity<Customer> {
         val customer = Customer("Bob", "bob@gmail.com")
         return ResponseEntity.ok(customer)

--- a/apps/api/src/main/resources/application.properties
+++ b/apps/api/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=sample

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true
+    path: /

--- a/gradle/local.versions.toml
+++ b/gradle/local.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 springbootVersion = "3.4.3"
 springDependencyPluginVersion = "1.1.6"
+springDocsVersion = "2.8.5"
 kotlinVersion = "2.0.21"
 junitPlatformLauncherVersion = "1.12.0"
 
@@ -8,6 +9,9 @@ junitPlatformLauncherVersion = "1.12.0"
 spring-boot-starter = { module = "org.springframework.boot:spring-boot-starter", version.ref = "springbootVersion" }
 spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web", version.ref = "springbootVersion" }
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "springbootVersion" }
+
+springdoc-openapi-starter-webmvc = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "springDocsVersion" }
+
 kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlinVersion" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatformLauncherVersion" }
 


### PR DESCRIPTION
Add and enable swagger docs for the `api` project.
- Add springdoc Gradle dependency to local version catalog.
- Rename `application.properties` to `application.yml`.
- Add standard springdoc configuration to enable it in `application.yml`.
- Use `@Operation` annotation to define swagger docs for the `GET /customer` endpoint.