### PR TITLE
feat: Add persistence layer using Exposed

### DIFF
--- a/apps/api/build.gradle.kts
+++ b/apps/api/build.gradle.kts
@@ -6,11 +6,21 @@ plugins {
 
 dependencies {
 	implementation(projects.model)
+	implementation(projects.persistence)
 
 	implementation(local.spring.boot.starter)
 	implementation(local.spring.boot.starter.web)
 
 	implementation(local.springdoc.openapi.starter.webmvc)
+
+	// Liquibase for database migrations
+	implementation(local.liquibase.core)
+
+	// H2 in-memory database
+	implementation(local.h2database)
+
+	// FasterXML Jackson module for Kotlin support
+	implementation(local.jackson.module.kotlin)
 
 	testImplementation(local.spring.boot.starter.test)
 	testImplementation(local.kotlin.test.junit5)

--- a/apps/api/src/main/kotlin/com/github/sample/controller/CustomerController.kt
+++ b/apps/api/src/main/kotlin/com/github/sample/controller/CustomerController.kt
@@ -1,28 +1,41 @@
 package com.github.sample.controller
 
 import com.github.sample.Customer
-import io.swagger.v3.oas.annotations.Operation
+import com.github.sample.CustomerInput
+import com.github.sample.service.CustomerService
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
-import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import java.util.UUID
 
 /**
  * REST controller for customers.
+ * This controller consists of endpoints for:
+ * - Saving customers.
+ * - Fetching customers.
+ *
+ * @param customerService [CustomerService] service layer.
  */
 @Controller
-class CustomerController {
+@RequestMapping("/customer")
+class CustomerController(private val customerService: CustomerService) : ICustomerController {
 
     /**
-     * Retrieve a customer.
+     * Retrieve a customer given an id.
+     * @param id [UUID] of customer.
      * @return [Customer]
      */
-    @GetMapping("/customer")
-    @Operation(
-        summary = "Retrieve a sample customer",
-        description = "Retrieve a sample customer"
-    )
-    fun getCustomer(): ResponseEntity<Customer> {
-        val customer = Customer("Bob", "bob@gmail.com")
+    override fun getCustomer(id: UUID): ResponseEntity<Customer> {
+        val customer = customerService.getCustomer(id)
         return ResponseEntity.ok(customer)
+    }
+
+    /**
+     * Save a customer.
+     * @param customer [Customer] to save.
+     * @return Saved [Customer]
+     */
+    override fun getCustomer(customer: CustomerInput): ResponseEntity<Customer> {
+        return ResponseEntity.ok(customerService.saveCustomer(customer))
     }
 }

--- a/apps/api/src/main/kotlin/com/github/sample/controller/ICustomerController.kt
+++ b/apps/api/src/main/kotlin/com/github/sample/controller/ICustomerController.kt
@@ -1,0 +1,39 @@
+package com.github.sample.controller
+
+import com.github.sample.Customer
+import com.github.sample.CustomerInput
+import io.swagger.v3.oas.annotations.Operation
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import java.util.UUID
+
+interface ICustomerController {
+
+    /**
+     * Retrieve a customer given an id.
+     * @param id [UUID] of customer.
+     * @return [Customer]
+     */
+    @GetMapping("/{id}")
+    @Operation(
+        summary = "Retrieve a customer given an id",
+        description = "Retrieve a customer given an id"
+    )
+    fun getCustomer(@PathVariable id: UUID): ResponseEntity<Customer>
+
+    /**
+     * Save a customer.
+     * @param customer [Customer] to save.
+     * @return Saved [Customer]
+     */
+    @PostMapping
+    @Operation(
+        summary = "Save a customer",
+        description = "Save a customer"
+    )
+    fun getCustomer(@Valid @RequestBody customer: CustomerInput): ResponseEntity<Customer>
+}

--- a/apps/api/src/main/kotlin/com/github/sample/service/CustomerService.kt
+++ b/apps/api/src/main/kotlin/com/github/sample/service/CustomerService.kt
@@ -1,0 +1,36 @@
+package com.github.sample.service
+
+import com.github.sample.Customer
+import com.github.sample.CustomerInput
+import com.github.sample.CustomerRepo
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+/**
+ * This service is responsible for:
+ * - Saving customers.
+ * - Fetching customers.
+ *
+ * @param customerRepo Exposed [CustomerRepo] to interact with the database.
+ */
+@Service
+class CustomerService(private val customerRepo: CustomerRepo) {
+
+    /**
+     * Save a customer.
+     * @param customer [CustomerInput] to save.
+     * @return [Customer] retrieved from database.
+     */
+    fun saveCustomer(customer: CustomerInput): Customer {
+        return customerRepo.saveCustomer(customer)
+    }
+
+    /**
+     * Get a customer given an id.
+     * @param id [UUID] to fetch customer.
+     * @return [Customer] or null if not found.
+     */
+    fun getCustomer(id: UUID): Customer? {
+        return customerRepo.getCustomer(id)
+    }
+}

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+spring:
+  liquibase:
+    enabled: true
 springdoc:
   api-docs:
     enabled: true

--- a/apps/api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/apps/api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,0 +1,3 @@
+databaseChangeLog:
+  - includeAll:
+      path: db/changelog/patch

--- a/apps/api/src/main/resources/db/changelog/patch/0001-initial-schema.yaml
+++ b/apps/api/src/main/resources/db/changelog/patch/0001-initial-schema.yaml
@@ -1,0 +1,18 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-customer-table
+      author: thorlauridsen
+      changes:
+        - createTable:
+            tableName: customer
+            columns:
+              - column:
+                  name: id
+                  type: UUID
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: mail
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false

--- a/gradle/local.versions.toml
+++ b/gradle/local.versions.toml
@@ -4,6 +4,10 @@ springDependencyPluginVersion = "1.1.6"
 springDocsVersion = "2.8.5"
 kotlinVersion = "2.0.21"
 junitPlatformLauncherVersion = "1.12.0"
+exposedVersion = "0.59.0"
+h2Version = "2.3.232"
+liquibaseVersion = "4.31.1"
+jacksonVersion = "2.18.2"
 
 [libraries]
 spring-boot-starter = { module = "org.springframework.boot:spring-boot-starter", version.ref = "springbootVersion" }
@@ -11,6 +15,14 @@ spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-start
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "springbootVersion" }
 
 springdoc-openapi-starter-webmvc = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "springDocsVersion" }
+
+exposed-spring-boot-starter = { module = "org.jetbrains.exposed:exposed-spring-boot-starter", version.ref = "exposedVersion" }
+
+h2database = { module = "com.h2database:h2", version.ref = "h2Version" }
+
+liquibase-core = { module = "org.liquibase:liquibase-core", version.ref = "liquibaseVersion" }
+
+jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jacksonVersion" }
 
 kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlinVersion" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatformLauncherVersion" }

--- a/modules/model/src/main/kotlin/com/github/sample/Customer.kt
+++ b/modules/model/src/main/kotlin/com/github/sample/Customer.kt
@@ -1,11 +1,13 @@
 package com.github.sample
 
+import java.util.UUID
+
 /**
  * Model data class representing a customer.
- * @param name Full name of customer.
+ * @param id [UUID] of customer.
  * @param mail Mail address of customer.
  */
 data class Customer(
-    val name: String,
+    val id: UUID,
     val mail: String,
 )

--- a/modules/model/src/main/kotlin/com/github/sample/CustomerInput.kt
+++ b/modules/model/src/main/kotlin/com/github/sample/CustomerInput.kt
@@ -1,0 +1,9 @@
+package com.github.sample
+
+/**
+ * Model data class used to create a new customer.
+ * @param mail Mail address of customer.
+ */
+data class CustomerInput(
+    val mail: String,
+)

--- a/modules/persistence/build.gradle.kts
+++ b/modules/persistence/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    kotlin("plugin.spring") version local.versions.kotlinVersion
+    alias(local.plugins.spring.boot)
+    alias(local.plugins.spring.dependencies)
+}
+
+dependencies {
+    implementation(projects.model)
+    implementation(local.exposed.spring.boot.starter)
+}

--- a/modules/persistence/src/main/kotlin/com/github/sample/CustomerRepo.kt
+++ b/modules/persistence/src/main/kotlin/com/github/sample/CustomerRepo.kt
@@ -1,0 +1,60 @@
+package com.github.sample
+
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.insertAndGetId
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+/**
+ * Exposed customer repository.
+ * This repository is responsible for:
+ * - Saving customers to the database.
+ * - Fetching customers from the database.
+ */
+@Repository
+class CustomerRepo {
+
+    /**
+     * Save a customer to the database.
+     * @param customer [CustomerInput] to save.
+     * @throws IllegalStateException if customer not found in database after saving.
+     * @return [Customer] retrieved from database.
+     */
+    fun saveCustomer(customer: CustomerInput): Customer {
+        return transaction {
+            val id = CustomerTable.insertAndGetId {
+                it[mail] = customer.mail
+            }
+            getCustomer(id.value) ?: error("Could not save customer with mail: $customer")
+        }
+    }
+
+    /**
+     * Get a customer from the database given an id.
+     * @param id [UUID] to fetch customer.
+     * @return [Customer] or null if not found.
+     */
+    fun getCustomer(id: UUID): Customer? {
+        return transaction {
+            CustomerTable
+                .selectAll()
+                .where { CustomerTable.id eq id }
+                .map { mapToCustomer(it) }
+                .firstOrNull()
+        }
+    }
+
+    /**
+     * Map ResultRow to a Customer.
+     * @param row [ResultRow]
+     * @return [Customer]
+     */
+    private fun mapToCustomer(row: ResultRow): Customer {
+        return Customer(
+            id = row[CustomerTable.id].value,
+            mail = row[CustomerTable.mail],
+        )
+    }
+}

--- a/modules/persistence/src/main/kotlin/com/github/sample/CustomerTable.kt
+++ b/modules/persistence/src/main/kotlin/com/github/sample/CustomerTable.kt
@@ -1,0 +1,11 @@
+package com.github.sample
+
+import org.jetbrains.exposed.dao.id.UUIDTable
+
+/**
+ * Exposed UUID table for customers.
+ * @property mail Mail address of customer.
+ */
+object CustomerTable : UUIDTable("customer") {
+    val mail = varchar("mail", 255)
+}


### PR DESCRIPTION
Add persistence layer which uses the Gradle dependency Exposed
- Add Gradle dependencies:
  - [Exposed](https://github.com/JetBrains/Exposed) which is a lightweight Kotlin SQL library.
  - [H2database](https://github.com/h2database) for in-memory database
  - [Liquibase](https://github.com/liquibase) for managing database changelogs
- Add subproject `persistence`:
  - Add `CustomerTable` to represent the database table for customers.
  - Add `CustomerRepo` to save and retrieve customers from the database.
- Update Customer model data class:
  - Remove val `name` to keep the data model in this project simple.
  - Add val `id` of type UUID to represent the id of the customer.
- Add model data class `CustomerInput` which will only contain the values necessary for creating a new customer.  
- Add Liquibase changelog for initial database schema.
- Enable Liquibase in `application.yml` for `api` project.
- Add `CustomerService` to represent the functional service layer of the `api` project.
  - This service will interact with the customer repository.
- Split `CustomerController` by adding `ICustomerController`.
  - `ICustomerController` will be responsible for defining the endpoints and the swagger docs.
  - `CustomerController` will interact with the service layer.   