### PR TITLE
refac: Update CustomerController and ICustomerController

### DIFF
--- a/apps/api/src/main/kotlin/com/github/sample/controller/CustomerController.kt
+++ b/apps/api/src/main/kotlin/com/github/sample/controller/CustomerController.kt
@@ -5,7 +5,7 @@ import com.github.sample.CustomerInput
 import com.github.sample.service.CustomerService
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
-import org.springframework.web.bind.annotation.RequestMapping
+import java.net.URI
 import java.util.UUID
 
 /**
@@ -17,7 +17,6 @@ import java.util.UUID
  * @param customerService [CustomerService] service layer.
  */
 @Controller
-@RequestMapping("/customer")
 class CustomerController(private val customerService: CustomerService) : ICustomerController {
 
     /**
@@ -36,6 +35,9 @@ class CustomerController(private val customerService: CustomerService) : ICustom
      * @return Saved [Customer]
      */
     override fun saveCustomer(customer: CustomerInput): ResponseEntity<Customer> {
-        return ResponseEntity.ok(customerService.saveCustomer(customer))
+        val savedCustomer = customerService.saveCustomer(customer)
+
+        val location = URI.create("$CUSTOMER_ENDPOINT/${savedCustomer.id}")
+        return ResponseEntity.created(location).body(savedCustomer)
     }
 }

--- a/apps/api/src/main/kotlin/com/github/sample/controller/ICustomerController.kt
+++ b/apps/api/src/main/kotlin/com/github/sample/controller/ICustomerController.kt
@@ -9,8 +9,12 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
 import java.util.UUID
 
+const val CUSTOMER_ENDPOINT = "/customer"
+
+@RequestMapping(CUSTOMER_ENDPOINT)
 interface ICustomerController {
 
     /**


### PR DESCRIPTION
- Move `@RequestMapping("/customer")` from `CustomerController` to `ICustomerController` so that all endpoint related things are managed in `ICustomerController`.
- Add constant `CUSTOMER_ENDPOINT` in `ICustomerController` to avoid typos when referencing the specific endpoint from various places.
- Update `CustomerController` to return a HTTP 201 when a customer is created with the endpoint location of where to retrieve the newly created customer.