### PR TITLE
fix: Disable bootJar and bootRun in persistence build.gradle.kts

### DIFF
--- a/modules/persistence/build.gradle.kts
+++ b/modules/persistence/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+import org.springframework.boot.gradle.tasks.run.BootRun
+
 plugins {
     kotlin("plugin.spring") version local.versions.kotlinVersion
     alias(local.plugins.spring.boot)
@@ -10,4 +13,13 @@ dependencies {
 
     // JetBrains Exposed - Kotlin SQL library
     implementation(local.exposed.spring.boot.starter)
+}
+
+// Disabling bootJar and bootRun is necessary for a subproject/module
+// that uses the Spring Boot plugin but is not supposed to be executable.
+tasks.named<BootJar>("bootJar") {
+    enabled = false
+}
+tasks.named<BootRun>("bootRun") {
+    enabled = false
 }


### PR DESCRIPTION
The `persistence` subproject is not supposed to be an independently executable subproject as it will be used by the `api` subproject which is runnable. To ensure that we can use `gradlew build` locally, we must disable Gradle tasks `bootJar` and `bootRun` because the `persistence` subproject has the Spring Boot plugin but should be runnable.